### PR TITLE
Handle current-directory database creation

### DIFF
--- a/NovaFitPlus/novafit_plus/db.py
+++ b/NovaFitPlus/novafit_plus/db.py
@@ -3,7 +3,9 @@ from contextlib import contextmanager
 
 @contextmanager
 def get_conn(db_path: str):
-    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    dir_name = os.path.dirname(db_path)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
     conn = sqlite3.connect(db_path)
     try:
         yield conn

--- a/NovaFitPlus/tests/test_db.py
+++ b/NovaFitPlus/tests/test_db.py
@@ -1,0 +1,15 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from novafit_plus.db import get_conn
+
+
+def test_get_conn_allows_plain_filenames(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db_file = "plain_name.db"
+    with get_conn(db_file) as conn:
+        conn.execute("SELECT 1")
+    assert os.path.isfile(db_file)


### PR DESCRIPTION
## Summary
- guard the database helper against empty directory components when creating paths
- add a regression test that opens a database using a filename without a directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e21a898228832bbade5649bc4620ed