### PR TITLE
Guard tail query with whitelist and add regression tests

### DIFF
--- a/NovaFitPlus/novafit_plus/app.py
+++ b/NovaFitPlus/novafit_plus/app.py
@@ -1,5 +1,5 @@
 from .utils import load_config, today_iso, clamp, print_box, ascii_bar
-from .db import init_db, upsert_user, get_user, upsert_activity, insert_weather, tail, migrate_schema, sleep_on_date
+from .db import init_db, upsert_user, get_user, upsert_activity, insert_weather, tail, migrate_schema, sleep_on_date, InvalidTableError
 from .db import add_water_intake, daily_water_total, weather_on_date
 from . import weather as wz
 from .profile import bmi, bmr_mifflin, maintenance_calories
@@ -194,14 +194,13 @@ def menu():
             seed_faker(db, user_name, days)
             print(f"Seed completed ({days} days).")
         elif op == "9":
-            print_box("users (last 5)")
-            print(tail(db, "users", 5))
-            print_box("activities (last 5)")
-            print(tail(db, "activities", 5))
-            print_box("weather (last 5)")
-            print(tail(db, "weather", 5))
-            print_box("water_intake (last 5)")
-            print(tail(db, "water_intake", 5))
+            tables = ("users", "activities", "weather", "water_intake")
+            for tbl in tables:
+                print_box(f"{tbl} (last 5)")
+                try:
+                    print(tail(db, tbl, 5))
+                except InvalidTableError as err:
+                    print(f"Table error: {err}")
         elif op == "0":
             print("Goodbye.")
             break

--- a/NovaFitPlus/novafit_plus/db.py
+++ b/NovaFitPlus/novafit_plus/db.py
@@ -56,6 +56,16 @@ SCHEMA = [
     );'''
 ]
 
+class InvalidTableError(ValueError):
+    pass
+
+_TAIL_SQL = {
+    "users": "SELECT * FROM users ORDER BY id DESC LIMIT ?",
+    "activities": "SELECT * FROM activities ORDER BY id DESC LIMIT ?",
+    "weather": "SELECT * FROM weather ORDER BY id DESC LIMIT ?",
+    "water_intake": "SELECT * FROM water_intake ORDER BY id DESC LIMIT ?",
+}
+
 def init_db(db_path: str):
     with get_conn(db_path) as c:
         cur = c.cursor()
@@ -164,7 +174,10 @@ def sleep_on_date(db_path: str, user_name: str, date: str) -> float:
         return float(r2[0]) if r2 and r2[0] is not None else 0.0
 
 def tail(db_path: str, table: str, n: int = 5):
+    sql = _TAIL_SQL.get(table)
+    if not sql:
+        raise InvalidTableError(f"Invalid table name: {table}")
     with get_conn(db_path) as c:
         cur = c.cursor()
-        cur.execute(f"SELECT * FROM {table} ORDER BY id DESC LIMIT ?", (n,))
+        cur.execute(sql, (n,))
         return cur.fetchall()

--- a/NovaFitPlus/tests/test_db_tail.py
+++ b/NovaFitPlus/tests/test_db_tail.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from novafit_plus.db import init_db, get_conn, tail, InvalidTableError
+
+
+def test_tail_allows_whitelisted_tables(tmp_path):
+    db_path = tmp_path / "test.db"
+    init_db(str(db_path))
+    with get_conn(str(db_path)) as conn:
+        cur = conn.cursor()
+        cur.execute("INSERT INTO users(name) VALUES (?)", ("Alice",))
+    rows = tail(str(db_path), "users", 5)
+    assert rows
+    assert rows[0][1] == "Alice"
+
+
+def test_tail_rejects_disallowed_table(tmp_path):
+    db_path = tmp_path / "test.db"
+    init_db(str(db_path))
+    with pytest.raises(InvalidTableError):
+        tail(str(db_path), "not_allowed")


### PR DESCRIPTION
## Summary
- enforce a whitelist-backed SQL mapping for tail queries to avoid unsafe table selection
- handle invalid table errors in the CLI menu when tailing tables
- add regression coverage verifying allowed tables succeed and disallowed names raise the controlled error

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e21a97d2cc832b9cb60b52ef15dd45