### PR TITLE
Ensure activities are unique per user/date

### DIFF
--- a/NovaFitPlus/README.md
+++ b/NovaFitPlus/README.md
@@ -32,6 +32,12 @@ python -m novafit_plus.ui_tk        # GUI
 9) Tail last rows
 0) Exit
 
+## Manual QA Checklist
+- Ensure the database is initialized by running `python -m novafit_plus.app` and seeding demo data if needed.
+- Log an activity for today via the CLI, then repeat the same option with different values for steps or notes to overwrite the entry.
+- Use option `9) Tail last rows` targeting the `activities` table to confirm only one record exists for the user/date pair and that it reflects the updated values.
+- Run the seeding helper twice (e.g., `python -m novafit_plus.seed`) or re-run option `8)` to observe the `[seed] Re-logged activity...` message confirming a single row per day.
+
 ### Health Score and Sleep Percentages
 - Dashboard shows **Weekly** and **Monthly** sleep percentages vs. an 8-hour target.
 - A **Health Score (7 days)** combines steps, hydration, sleep and mood, with a small BMI adjustment. Scale 0–100.

--- a/NovaFitPlus/novafit_plus/db.py
+++ b/NovaFitPlus/novafit_plus/db.py
@@ -33,6 +33,8 @@ SCHEMA = [
         sleep_hours REAL,
         FOREIGN KEY(user_id) REFERENCES users(id)
     );''',
+    '''CREATE UNIQUE INDEX IF NOT EXISTS idx_activities_user_date
+        ON activities(user_id, date);''',
     '''CREATE TABLE IF NOT EXISTS weather (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         date TEXT NOT NULL,
@@ -72,6 +74,23 @@ def migrate_schema(db_path: str):
                 cur.execute("ALTER TABLE activities ADD COLUMN sleep_hours REAL")
             except Exception:
                 pass
+        cur.execute("PRAGMA index_list(activities)")
+        indexes = {row[1] for row in cur.fetchall()}
+        if "idx_activities_user_date" not in indexes:
+            cur.execute(
+                """
+                DELETE FROM activities
+                WHERE id NOT IN (
+                    SELECT MIN(id) FROM activities GROUP BY user_id, date
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_activities_user_date
+                    ON activities(user_id, date)
+                """
+            )
 
 def upsert_user(db_path: str, name: str, age: int, sex: str, height_cm: float, weight_kg: float, activity_level: str):
     with get_conn(db_path) as c:
@@ -95,7 +114,13 @@ def upsert_activity(db_path: str, user_name: str, date: str, steps: int, calorie
         user_id = cur.fetchone()[0]
         cur.execute(
             '''INSERT INTO activities(user_id, date, steps, calories, mood, notes, sleep_hours)
-               VALUES(?,?,?,?,?,?,?)''',
+               VALUES(?,?,?,?,?,?,?)
+               ON CONFLICT(user_id, date) DO UPDATE SET
+                   steps=excluded.steps,
+                   calories=excluded.calories,
+                   mood=excluded.mood,
+                   notes=excluded.notes,
+                   sleep_hours=excluded.sleep_hours''',
             (user_id, date, steps, calories, mood, notes, sleep_hours)
         )
 

--- a/NovaFitPlus/novafit_plus/seed.py
+++ b/NovaFitPlus/novafit_plus/seed.py
@@ -1,8 +1,28 @@
 import datetime as dt, random
-from .db import upsert_user, upsert_activity, add_water_intake
+from .db import add_water_intake, get_conn, upsert_activity, upsert_user
+
+
+def _activity_row_count(db_path: str, user: str, date: str) -> int:
+    with get_conn(db_path) as c:
+        cur = c.cursor()
+        cur.execute("SELECT id FROM users WHERE name=?", (user,))
+        row = cur.fetchone()
+        if not row:
+            return 0
+        cur.execute("SELECT COUNT(*) FROM activities WHERE user_id=? AND date=?", (row[0], date))
+        count = cur.fetchone()[0]
+        return int(count or 0)
+
+
+def _demonstrate_repeat_log(db_path: str, user: str, date: str, steps: int, calories: int, mood: int, notes: str, sleep: float):
+    upsert_activity(db_path, user, date, steps, calories, mood, notes, sleep)
+    total = _activity_row_count(db_path, user, date)
+    print(f"[seed] Re-logged activity for {user} on {date}; rows now: {total} (expected 1).")
+
 
 def seed_user(db_path: str, name="Kevin", age=30, sex="M", height_cm=166, weight_kg=66, activity_level="light"):
     upsert_user(db_path, name, age, sex, height_cm, weight_kg, activity_level)
+
 
 def seed_random(db_path: str, user: str, days: int = 21):
     today = dt.date.today()
@@ -15,9 +35,26 @@ def seed_random(db_path: str, user: str, days: int = 21):
         sleep = round(random.uniform(5.0, 9.0), 2)
         upsert_activity(db_path, user, day.isoformat(), steps, calories, mood, notes, sleep)
         for _ in range(random.randint(4, 10)):
-            ml = random.choice([150,200,250,300,350,400,500,600])
-            source = random.choice(["glass","bottle","thermos","fountain"])
+            ml = random.choice([150, 200, 250, 300, 350, 400, 500, 600])
+            source = random.choice(["glass", "bottle", "thermos", "fountain"])
             add_water_intake(db_path, user, day.isoformat(), ml, source)
+    if days > 0:
+        verify_steps = random.randint(3000, 15000)
+        verify_calories = random.randint(1600, 2800)
+        verify_mood = random.randint(2, 5)
+        verify_notes = "Updated log after repeat entry"
+        verify_sleep = round(random.uniform(5.0, 9.0), 2)
+        _demonstrate_repeat_log(
+            db_path,
+            user,
+            today.isoformat(),
+            verify_steps,
+            verify_calories,
+            verify_mood,
+            verify_notes,
+            verify_sleep,
+        )
+
 
 def seed_faker(db_path: str, user: str, days: int = 21):
     try:
@@ -37,6 +74,22 @@ def seed_faker(db_path: str, user: str, days: int = 21):
         sleep = round(fake.pyfloat(left_digits=1, right_digits=2, positive=True, max_value=10), 2)
         upsert_activity(db_path, user, day.isoformat(), steps, calories, mood, notes, sleep)
         for _ in range(fake.pyint(min_value=4, max_value=10)):
-            ml = fake.random_element(elements=(150,200,250,300,350,400,500,600))
-            source = fake.random_element(elements=("glass","bottle","thermos","fountain"))
+            ml = fake.random_element(elements=(150, 200, 250, 300, 350, 400, 500, 600))
+            source = fake.random_element(elements=("glass", "bottle", "thermos", "fountain"))
             add_water_intake(db_path, user, day.isoformat(), ml, source)
+    if days > 0:
+        verify_steps = int(7000 + fake.pyint(min_value=-1500, max_value=2000))
+        verify_calories = int(1800 + fake.pyint(min_value=-300, max_value=450))
+        verify_mood = fake.pyint(min_value=1, max_value=5)
+        verify_notes = "Updated log after repeat entry"
+        verify_sleep = round(fake.pyfloat(left_digits=1, right_digits=2, positive=True, max_value=10), 2)
+        _demonstrate_repeat_log(
+            db_path,
+            user,
+            today.isoformat(),
+            verify_steps,
+            verify_calories,
+            verify_mood,
+            verify_notes,
+            verify_sleep,
+        )


### PR DESCRIPTION
## Summary
- add a unique index for activities on (user_id, date) with migration cleanup
- switch activity upsert logic to update existing rows when re-logging the same day
- enhance seeding feedback and manual QA docs to confirm repeated logs keep a single row

## Testing
- python -m compileall novafit_plus

------
https://chatgpt.com/codex/tasks/task_e_68e21a9c3240832b9cece1540947343e