### PR TITLE
Add city and country profile support across NovaFit Plus

### DIFF
--- a/NovaFitPlus/novafit_plus/app.py
+++ b/NovaFitPlus/novafit_plus/app.py
@@ -8,15 +8,39 @@ from .analysis import kpis, best_running_days, hydration_adherence, sleep_stats,
 from .export import export_json, export_excel
 from typing import Optional
 
+
+def _default_profile(name: str):
+    return (None, name, 30, "M", 166, 66, "light", "", "")
+
+
 def onboarding(db, default_name="Kevin"):
     print_box("Onboarding — Profile")
-    name = input(f"Name (default {default_name}): ").strip() or default_name
-    age = int(input("Age: ") or 30)
-    sex = input("Sex (M/F/Other): ").strip() or "M"
-    height_cm = float(input("Height cm: ") or 166)
-    weight_kg = float(input("Weight kg: ") or 66)
-    activity_level = input("Activity level (sedentary/light/moderate/active) [light]: ").strip().lower() or "light"
-    upsert_user(db, name, age, sex, height_cm, weight_kg, activity_level)
+    cfg = load_config()
+    existing = get_user(db, default_name)
+    if existing:
+        _, ex_name, ex_age, ex_sex, ex_h, ex_w, ex_al, ex_city, ex_country = existing
+    else:
+        _, ex_name, ex_age, ex_sex, ex_h, ex_w, ex_al, ex_city, ex_country = _default_profile(default_name)
+    name_default = ex_name or default_name
+    name = input(f"Name (default {name_default}): ").strip() or name_default
+    age = int(input(f"Age [{ex_age}]: ").strip() or ex_age)
+    sex = input(f"Sex (M/F/Other) [{ex_sex}]: ").strip() or ex_sex
+    height_cm = float(input(f"Height cm [{ex_h}]: ").strip() or ex_h)
+    weight_kg = float(input(f"Weight kg [{ex_w}]: ").strip() or ex_w)
+    activity_level_default = (ex_al or "light").lower()
+    activity_level = (
+        input(
+            f"Activity level (sedentary/light/moderate/active) [{activity_level_default}]: "
+        )
+        .strip()
+        .lower()
+        or activity_level_default
+    )
+    city_default = ex_city or cfg.get("default_city", "")
+    country_default = ex_country or cfg.get("default_country", "")
+    city = input(f"City (default {city_default or 'n/a'}): ").strip() or city_default
+    country = input(f"Country (default {country_default or 'n/a'}): ").strip() or country_default
+    upsert_user(db, name, age, sex, height_cm, weight_kg, activity_level, city, country)
     val, cat = bmi(weight_kg, height_cm)
     bmr = bmr_mifflin(age, sex, height_cm, weight_kg)
     maint = maintenance_calories(bmr, activity_level)
@@ -54,14 +78,19 @@ def log_water(db, user_name):
 
 def dashboard(db, user_name):
     print_box("Daily Dashboard")
-    u = get_user(db, user_name) or (None, user_name, 30, "M", 166, 66, "light")
-    _, name, age, sex, h, w, al = u
+    u = get_user(db, user_name) or _default_profile(user_name)
+    _, name, age, sex, h, w, al, city, country = u
     b, cat = bmi(w, h)
     bmr = bmr_mifflin(age, sex, h, w)
     maint = maintenance_calories(bmr, al)
     prog = hydration_progress(db, user_name, today_iso(), w)
     bar = ascii_bar(prog["total_ml"], prog["goal_ml"])
     print(f"User: {name} | Age: {age} | Sex: {sex} | Activity: {al}")
+    if city or country:
+        loc_parts = [part for part in (city, country) if part]
+        print(f"Location: {', '.join(loc_parts)}")
+    else:
+        print("Location: not set")
     print(f"Height: {h} cm | Weight: {w} kg | BMI: {b} ({cat})")
     print(f"BMR: {bmr} kcal | Maintenance: {maint} kcal")
     print(f"Hydration: {prog['total_ml']}/{prog['goal_ml']} ml {bar} (remaining {prog['remaining_ml']} ml)")
@@ -81,7 +110,9 @@ def dashboard(db, user_name):
         if ans == 'y':
             cfg = load_config()
             try:
-                lat, lon, cname = wz.geocode_city(cfg['default_city'], cfg['default_country'])
+                fetch_city = (city or '').strip() or cfg['default_city']
+                fetch_country = (country or '').strip() or cfg['default_country']
+                lat, lon, cname = wz.geocode_city(fetch_city, fetch_country)
                 data = wz.fetch_daily_forecast(lat, lon, days=1)
                 daily = data.get('daily', {})
                 for i, d in enumerate(daily.get('time', [])):
@@ -101,10 +132,13 @@ def dashboard(db, user_name):
         else:
             print("Skipping weather fetch.")
 
-def fetch_weather(db, cfg):
+def fetch_weather(db, cfg, user_name):
     print_box("Weather Fetch")
-    city = input(f"City (default {cfg['default_city']}): ").strip() or cfg["default_city"]
-    country = input(f"Country (default {cfg['default_country']}): ").strip() or cfg["default_country"]
+    profile = get_user(db, user_name)
+    city_default = (profile[7] if profile else "") or cfg["default_city"]
+    country_default = (profile[8] if profile else "") or cfg["default_country"]
+    city = input(f"City (default {city_default}): ").strip() or city_default
+    country = input(f"Country (default {country_default}): ").strip() or country_default
     days = int(input("Days (1-7): ") or 1)
     days = max(1, min(days, 7))
     lat, lon, cname = wz.geocode_city(city, country)
@@ -129,8 +163,8 @@ def do_analytics(db, user_name):
     for d, cond, score in best_running_days(db, days):
         print(f"{d} — {cond} — Score: {score}")
     print_box("Hydration adherence (last 7 days)")
-    u = get_user(db, user_name) or (None, user_name, 30, "M", 166, 66, "light")
-    _, name, age, sex, h, w, al = u
+    u = get_user(db, user_name) or _default_profile(user_name)
+    _, _, _, _, h, w, al, _, _ = u
     rep = hydration_adherence(db, user_name, w, days=7)
     for row in rep:
         print(row)
@@ -183,7 +217,7 @@ def menu(config_path: Optional[str] = None):
         elif op == "4":
             dashboard(db, user_name)
         elif op == "5":
-            fetch_weather(db, cfg)
+            fetch_weather(db, cfg, user_name)
         elif op == "6":
             do_analytics(db, user_name)
         elif op == "7":

--- a/NovaFitPlus/novafit_plus/export.py
+++ b/NovaFitPlus/novafit_plus/export.py
@@ -8,11 +8,23 @@ def export_json(db_path: str, export_dir: str, user_name: str, days: int = 14) -
 
     with get_conn(db_path) as c:
         cur = c.cursor()
-        cur.execute("SELECT id, name, age, sex, height_cm, weight_kg, activity_level FROM users WHERE name=?", (user_name,))
+        cur.execute(
+            "SELECT id, name, age, sex, height_cm, weight_kg, activity_level, city, country FROM users WHERE name=?",
+            (user_name,),
+        )
         u = cur.fetchone()
         if u:
-            uid, name, age, sex, h, w, al = u
-            data["profile"] = {"name": name, "age": age, "sex": sex, "height_cm": h, "weight_kg": w, "activity_level": al}
+            uid, name, age, sex, h, w, al, city, country = u
+            data["profile"] = {
+                "name": name,
+                "age": age,
+                "sex": sex,
+                "height_cm": h,
+                "weight_kg": w,
+                "activity_level": al,
+                "city": city,
+                "country": country,
+            }
         else:
             uid = None
 
@@ -56,12 +68,24 @@ def export_excel(db_path: str, export_dir: str, user_name: str, days: int = 14) 
     with get_conn(db_path) as c:
         cur = c.cursor()
         # Profile
-        cur.execute("SELECT id, name, age, sex, height_cm, weight_kg, activity_level FROM users WHERE name=?", (user_name,))
+        cur.execute(
+            "SELECT id, name, age, sex, height_cm, weight_kg, activity_level, city, country FROM users WHERE name=?",
+            (user_name,),
+        )
         u = cur.fetchone()
         ws_profile.append(["field", "value"])
         if u:
-            uid, name, age, sex, h, w, al = u
-            for k, v in [("name", name), ("age", age), ("sex", sex), ("height_cm", h), ("weight_kg", w), ("activity_level", al)]:
+            uid, name, age, sex, h, w, al, city, country = u
+            for k, v in [
+                ("name", name),
+                ("age", age),
+                ("sex", sex),
+                ("height_cm", h),
+                ("weight_kg", w),
+                ("activity_level", al),
+                ("city", city),
+                ("country", country),
+            ]:
                 ws_profile.append([k, v])
         else:
             uid = None

--- a/NovaFitPlus/novafit_plus/seed.py
+++ b/NovaFitPlus/novafit_plus/seed.py
@@ -20,8 +20,24 @@ def _demonstrate_repeat_log(db_path: str, user: str, date: str, steps: int, calo
     print(f"[seed] Re-logged activity for {user} on {date}; rows now: {total} (expected 1).")
 
 
-def seed_user(db_path: str, name="Kevin", age=30, sex="M", height_cm=166, weight_kg=66, activity_level="light"):
-    upsert_user(db_path, name, age, sex, height_cm, weight_kg, activity_level)
+def seed_user(
+    db_path: str,
+    name="Kevin",
+    age=30,
+    sex="M",
+    height_cm=166,
+    weight_kg=66,
+    activity_level="light",
+    city=None,
+    country=None,
+):
+    if city is None or country is None:
+        from .utils import load_config  # local import keeps seeding lightweight 🤖
+
+        cfg = load_config()
+        city = cfg.get("default_city", "") if city is None else city
+        country = cfg.get("default_country", "") if country is None else country
+    upsert_user(db_path, name, age, sex, height_cm, weight_kg, activity_level, city or "", country or "")
 
 
 def seed_random(db_path: str, user: str, days: int = 21):

--- a/NovaFitPlus/tests/test_db.py
+++ b/NovaFitPlus/tests/test_db.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from novafit_plus.db import get_conn
+from novafit_plus.db import get_conn, init_db, migrate_schema, upsert_user, get_user
+from novafit_plus.utils import load_config
 
 
 def test_get_conn_allows_plain_filenames(tmp_path, monkeypatch):
@@ -13,3 +14,58 @@ def test_get_conn_allows_plain_filenames(tmp_path, monkeypatch):
     with get_conn(db_file) as conn:
         conn.execute("SELECT 1")
     assert os.path.isfile(db_file)
+
+
+def test_migrate_schema_adds_location_columns(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    init_db(str(db_path))
+    with get_conn(str(db_path)) as conn:
+        cur = conn.cursor()
+        cur.execute("DROP TABLE users")
+        cur.execute(
+            '''CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                age INTEGER,
+                sex TEXT,
+                height_cm REAL,
+                weight_kg REAL,
+                activity_level TEXT,
+                created_at TEXT
+            )'''
+        )
+        cur.execute(
+            "INSERT INTO users(name, age, sex, height_cm, weight_kg, activity_level, created_at) VALUES (?,?,?,?,?,?,DATE('now'))",
+            ("Alice", 28, "F", 165.0, 60.0, "light"),
+        )
+    migrate_schema(str(db_path))
+    cfg = load_config()
+    with get_conn(str(db_path)) as conn:
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(users)")
+        cols = {row[1] for row in cur.fetchall()}
+        assert "city" in cols and "country" in cols
+        cur.execute("SELECT city, country FROM users WHERE name=?", ("Alice",))
+        city, country = cur.fetchone()
+        assert city == cfg.get("default_city")
+        assert country == cfg.get("default_country")
+
+
+def test_upsert_user_round_trip_with_location(tmp_path):
+    db_path = tmp_path / "profile.db"
+    init_db(str(db_path))
+    migrate_schema(str(db_path))
+    upsert_user(
+        str(db_path),
+        "Bob",
+        32,
+        "M",
+        178.0,
+        80.0,
+        "moderate",
+        "Lisbon",
+        "Portugal",
+    )
+    row = get_user(str(db_path), "Bob")
+    assert row[7] == "Lisbon"
+    assert row[8] == "Portugal"


### PR DESCRIPTION
## Summary
- add `city` and `country` columns to the users table with migration backfilling config defaults
- update CLI onboarding, dashboard, and weather fetches plus the GUI profile/weather tabs to use stored location data
- include location fields in exports and extend database tests to cover migrations and persistence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e22537f77c832b8d0614a16d053b2b