### PR TITLE
Add hydration goal vs actual chart and update GUI reports

### DIFF
--- a/NovaFitPlus/README.md
+++ b/NovaFitPlus/README.md
@@ -61,4 +61,5 @@ This script creates `.venv/`, installs `requirements.txt`, and launches the app.
 - `Export` tab: CSV/JSON/Excel.
 - `Reports` tab: generates PNG charts in `exports/charts/`:
   - `hydration_pct.png` (adherencia de hidratación)
+  - `hydration_goal_vs_actual.png` (consumo real vs meta de hidratación)
   - `steps_vs_sleep.png` (relación entre pasos y sueño)

--- a/NovaFitPlus/novafit_plus/ui_tk.py
+++ b/NovaFitPlus/novafit_plus/ui_tk.py
@@ -285,13 +285,13 @@ def main(config_path: Optional[str] = None):
             days = int(rep_days_var.get() or 14)
             u = get_user(db, user_var.get().strip() or default_user) or (None, default_user, 30, 'M', 166, 66, 'light')
             _, _, _, _, h, w, _ = u
-            p1 = chart_hydration(db, user_var.get().strip() or default_user, w, days)
+            pct_path, comparison_path = chart_hydration(db, user_var.get().strip() or default_user, w, days)
             p2 = chart_steps_vs_sleep(db, user_var.get().strip() or default_user, days)
-            txt_rep.delete('1.0', tk.END); txt_rep.insert(tk.END, f"Charts saved:\n{p1}\n{p2}")
+            txt_rep.delete('1.0', tk.END); txt_rep.insert(tk.END, f"Charts saved:\n{pct_path}\n{comparison_path}\n{p2}")
             # Try to preview the last chart
             try:
                 from tkinter import PhotoImage
-                img = PhotoImage(file=p1)
+                img = PhotoImage(file=comparison_path)
                 img_label.configure(image=img)
                 img_label.image = img
             except Exception:

--- a/NovaFitPlus/tests/test_reports.py
+++ b/NovaFitPlus/tests/test_reports.py
@@ -1,0 +1,23 @@
+import datetime as dt
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from novafit_plus.db import add_water_intake, init_db, upsert_user
+from novafit_plus.reports import chart_hydration
+
+
+def test_chart_hydration_creates_both_charts(tmp_path):
+    db_path = tmp_path / "hydration.db"
+    init_db(str(db_path))
+    upsert_user(str(db_path), "TestUser", 30, "F", 165, 60, "light")
+    today = dt.date.today()
+    for offset in range(3):
+        date = (today - dt.timedelta(days=offset)).isoformat()
+        add_water_intake(str(db_path), "TestUser", date, 600 + offset * 50, "glass")
+
+    pct_path, comparison_path = chart_hydration(str(db_path), "TestUser", 60, days=3, outdir=str(tmp_path))
+
+    assert Path(pct_path).is_file()
+    assert Path(comparison_path).is_file()


### PR DESCRIPTION
## Summary
- add a dual-line hydration goal vs actual chart alongside the existing hydration percentage plot
- update the GUI report generator to surface the new chart and list all saved chart paths
- document the new output asset and add a smoke test covering hydration chart generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e22538cd9c832b92836a25206546f7